### PR TITLE
chore: update zenn-cli to ^0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "zenn-cli": "^0.2.10"
+        "zenn-cli": "^0.3.0"
       }
     },
     "node_modules/bundle-name": {
@@ -161,10 +161,9 @@
       }
     },
     "node_modules/zenn-cli": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.2.10.tgz",
-      "integrity": "sha512-+1tAbDM9wsbRfrQtDGEN/i0bB1d26RqjtPmgBm672zflcTw/C8A/9qUA4fH4/TMmCGdOyNvohUE2B5ERd9EOZg==",
-      "license": "MIT",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.3.0.tgz",
+      "integrity": "sha512-L766eu5yeqytglvuTepfEnWMJGTCaQsVHiLFNKs9I6UtFS9jJ6hrjxD5Ys5m8D5sKKC8N4i5R/rb+JfC/PXQVA==",
       "dependencies": {
         "open": "^10.2.0"
       },
@@ -250,9 +249,9 @@
       }
     },
     "zenn-cli": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.2.10.tgz",
-      "integrity": "sha512-+1tAbDM9wsbRfrQtDGEN/i0bB1d26RqjtPmgBm672zflcTw/C8A/9qUA4fH4/TMmCGdOyNvohUE2B5ERd9EOZg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.3.0.tgz",
+      "integrity": "sha512-L766eu5yeqytglvuTepfEnWMJGTCaQsVHiLFNKs9I6UtFS9jJ6hrjxD5Ys5m8D5sKKC8N4i5R/rb+JfC/PXQVA==",
       "requires": {
         "open": "^10.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/miyataka/zenn-contents#readme",
   "dependencies": {
-    "zenn-cli": "^0.2.10"
+    "zenn-cli": "^0.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- `zenn-cli` を `^0.2.10` から `^0.3.0` にアップデート
- `package-lock.json` を更新

## Test plan
- [ ] `npx zenn preview` が正常に動作することを確認
- [ ] 記事のプレビューが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)